### PR TITLE
Add windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,28 @@
 # GIMP-Selection-Refiner
-GIMP Plugin to refine a selection using a neural network
+GIMP Plugin to refine a selection using the neural network segment-anything2
 
 ![Image](https://github.com/user-attachments/assets/5cd938df-5dc3-40b1-87e2-4649a9401c07)
 
 
-## Made for Gimp3.0. Works only on Linux
+## Made for Gimp 3.0.
 
 ## Installation:
 
-### Windows: FOR NOW ONLY SAM 1.0
+### Linux:
 
+1. Install python
+
+2. Rename the folder to `selection_refiner` and place it in your Gimp Plugins directory.
+  To find it, go inside GIMP to `Edit`->`Preferences`->`Folders`->`Plugins`. The folder must be named `selection_refiner`!!!
+
+
+3. make the python file executable, install dependencies and download model files with: 
+
+```
+bash ./setup.sh
+```
+
+### Windows:
 
 1. Install python
 
@@ -22,7 +35,6 @@ GIMP Plugin to refine a selection using a neural network
 ```
 setup.bat
 ```
-
  
 
 

--- a/README.md
+++ b/README.md
@@ -8,20 +8,23 @@ GIMP Plugin to refine a selection using a neural network
 
 ## Installation:
 
-### Linux: 
+### Windows: FOR NOW ONLY SAM 1.0
+
+
 1. Install python
 
 2. Rename the folder to `selection_refiner` and place it in your Gimp Plugins directory.
   To find it, go inside GIMP to `Edit`->`Preferences`->`Folders`->`Plugins`. The folder must be named `selection_refiner`!!!
 
 
-3. make the python file executable and install dependencies with: 
+3. install dependencies and download model files by double clicking
 
 ```
-bash ./setup.sh
+setup.bat
 ```
 
  
+
 
 ## Usage:
 1. Select the item roughly (make sure the entire object is in the selection)

--- a/sam_inference.py
+++ b/sam_inference.py
@@ -1,0 +1,46 @@
+print("running SAM inference")
+
+from os.path import join
+import sys
+import numpy as np
+#import torch
+from PIL import Image
+
+# use SAM 1 for now
+from segment_anything import SamPredictor, sam_model_registry
+print("done importing, stating to set up model")
+
+
+if __name__=="__main__":
+    
+    x1, y1, x2, y2, new_w, new_h, original_w, original_h, baseLoc = sys.argv[1:]
+    x1, y1, x2, y2, new_w, new_h, original_w, original_h = map(int, [x1, y1, x2, y2, new_w, new_h, original_w, original_h])
+
+    # set checkpoint
+    sam_checkpoint = join(baseLoc, "sam_vit_b_01ec64.pth")
+    image = Image.open(join(baseLoc, "rgb.png"))
+    im = np.array(image.resize((new_w, new_h)))
+
+    # load SAM
+    #device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    SAM_VERSION = 1
+    if SAM_VERSION == 1:
+        sam = sam_model_registry["vit_b"](checkpoint=sam_checkpoint)
+        #sam.to(device=device)
+        predictor = SamPredictor(sam)
+    elif SAM_VERSION == 2:
+        sam2_model = build_sam2(sam_cfg, sam_checkpoint, device=device)
+        predictor = SAM2ImagePredictor(sam2_model)
+    print("done setting up model, starting inference...")
+    
+    predictor.set_image(im)
+
+    # sam prediction
+    bounds = np.array([x1, y1 , x2, y2])
+    masks, _, _ = predictor.predict(box=bounds, multimask_output=False)
+
+    mask_rgba = np.zeros((masks[0].shape[0], masks[0].shape[1], 4), dtype=np.uint8)
+    mask_rgba[masks[0] == 1] = [255, 255, 255, 255]  # White with full opacity
+
+    Image.fromarray(mask_rgba).resize((original_w, original_h)).save(join(baseLoc,"mask.png"))
+    print("done with inference")

--- a/selection_refiner.py
+++ b/selection_refiner.py
@@ -3,6 +3,8 @@ import os
 from os.path import join
 import sys
 import subprocess
+import platform
+
 
 # This Plugin is only for GIMP Version >= 3.0.0 and windows
 import gi
@@ -15,24 +17,69 @@ from gi.repository import GLib
 from gi.repository import Gegl
 from gi.repository import Gio
 
-
+current_platform = platform.system().lower()
 baseLoc = os.path.dirname(os.path.realpath(__file__))
+
+
+if current_platform != "windows":
+    for version in range(6,20):
+        sys.path.extend([baseLoc+f'gimpenv/lib/python3.{version}', baseLoc+f'gimpenv/lib/python3.{version}/site-packages', baseLoc+f'gimpenv/lib/python3.{version}/site-packages/setuptools'])
+    sys.path.extend([baseLoc+'gimpenv/Lib', baseLoc+'gimpenv/Lib/site-packages', baseLoc+'gimpenv/Lib/site-packages/setuptools'])
+    sys.path.extend([baseLoc])
+
+
+    import numpy as np
+    import torch
+    from PIL import Image
+
+    SAM_VERSION = 2
+    SAM_SIZE = "base"
+
+    if SAM_VERSION == 1:
+        from segment_anything import SamPredictor, sam_model_registry
+    elif SAM_VERSION == 2:
+        from sam2.build_sam import build_sam2
+        from sam2.sam2_image_predictor import SAM2ImagePredictor
+
+
+    # set checkpoint
+    if SAM_VERSION == 1:
+        sam_checkpoint = os.path.join(baseLoc, "sam_vit_l_0b3195.pth")
+    elif SAM_VERSION == 2:
+        if SAM_SIZE == "small":
+            sam_cfg = "configs/sam2.1/sam2.1_hiera_s.yaml"
+            sam_checkpoint = os.path.join(baseLoc, "sam2.1_hiera_small.pt")
+        elif SAM_SIZE == "large":
+            sam_cfg = "configs/sam2.1/sam2.1_hiera_l.yaml"
+            sam_checkpoint = os.path.join(baseLoc, "sam2.1_hiera_large.pt")
+        else: # base
+            sam_cfg = "configs/sam2.1/sam2.1_hiera_b+.yaml"
+            sam_checkpoint = os.path.join(baseLoc, "sam2.1_hiera_base_plus.pt")
+
+
+
 
 class SelectionRefinerSAM(Gimp.PlugIn):
 
     ## GimpPlugIn virtual methods ##
     def do_query_procedures(self):
-        return [ 'python-plugin-selection-refiner-sam-win' ]
+        procedure = 'python-plugin-selection-refiner-sam-win' if current_platform == "windows" else 'python-plugin-selection-refiner-sam'
+        return [procedure ]
 
 
     def do_create_procedure(self, name):
         self.mode = "select"
         procedure = None
         
-        procedure = Gimp.ImageProcedure.new(self, name,
-                                            Gimp.PDBProcType.PLUGIN,
-                                            self.refine_selection, None)
-        
+        if name == 'python-plugin-selection-refiner-sam-win':
+            procedure = Gimp.ImageProcedure.new(self, name,
+                                                Gimp.PDBProcType.PLUGIN,
+                                                self.refine_selection_win, None)
+        else:
+            procedure = Gimp.ImageProcedure.new(self, name,
+                                    Gimp.PDBProcType.PLUGIN,
+                                    self.refine_selection, None)
+            
         procedure.set_sensitivity_mask(Gimp.ProcedureSensitivityMask.ALWAYS)
 
         procedure.set_documentation(
@@ -47,10 +94,10 @@ class SelectionRefinerSAM(Gimp.PlugIn):
 
         return procedure
         
-    def refine_selection(self, procedure, run_mode, image, drawables, config, data):
+    # call external python interpreter (for windows)
+    def refine_selection_win(self, procedure, run_mode, image, drawables, config, data):
         
         image.undo_group_start()
-
 
 
         #GimpUi.init("python-plugin-selection-refiner-sam-win")
@@ -77,7 +124,7 @@ class SelectionRefinerSAM(Gimp.PlugIn):
         #Inference
         python_path = join(baseLoc, "gimpenv", "Scripts", "python.exe")
         inference_script = join(baseLoc, "sam_inference.py")
-        args = [str(x1), str(y1), str(x2), str(y2), str(new_w), str(new_h), str(w), str(h), baseLoc]
+        args = [str(x1), str(y1), str(x2), str(y2), str(new_w), str(new_h), str(w), str(h)]
 
         command = [python_path, inference_script] + args
 
@@ -98,7 +145,90 @@ class SelectionRefinerSAM(Gimp.PlugIn):
 
         return procedure.new_return_values(Gimp.PDBStatusType.SUCCESS, None)
         
+
+    # direct execution (for linux)
+    def refine_selection(self, procedure, run_mode, image, drawables, config, data):
+        
+        image.undo_group_start()
+
+        #GimpUi.init("python-plugin-selection-refiner-sam")
+        #dialog = GimpUi.ProcedureDialog.new(procedure, config, "Run Plugin")
+        #dialog.fill(["please wait"])
+        #dialog.run()
+        #dialog.fill(["please wait"])
+        layer = drawables[0]
+        w,h = layer.get_width(), layer.get_height()
+        scale = 1024 / max(w, h)
+        new_w, new_h = int(w*scale), int(h*scale)
+
+        selection = Gimp.Selection.bounds(image)
+        selection_bounds = np.array([selection.x1 * scale, selection.y1 * scale, 
+                                     selection.x2 * scale, selection.y2 * scale], dtype=np.int64)
+
+        
+        # get the image as numpy array (https://gitlab.gnome.org/GNOME/gimp/-/issues/8686)
+        rect = Gegl.Rectangle.new(0, 0, w, h)
+        buffer1 = layer.get_buffer()
+        buffer_bytes = buffer1.get(rect, 1.0, "RGBA u8", Gegl.AbyssPolicy(0))
+        image_arr = np.frombuffer(buffer_bytes, dtype=np.uint8).reshape((h,w,-1))
+
+        #Inference
+        result_layer_arr = self.sam_infer(image_arr[:,:,:3], selection_bounds, new_w, new_h, w, h)
+        
+        result_layer = Gimp.Layer().new(image, "result", w, h, Gimp.ImageType.RGBA_IMAGE, 1, Gimp.LayerMode.NORMAL)
+        image.insert_layer(result_layer, None, 1)
+        buffer2 = result_layer.get_buffer()
+        if self.mode == "select":
+            rect = Gegl.Rectangle.new(0, 0, w, h)
+            buffer2.set(rect, "RGBA u8" , result_layer_arr.tobytes())
+            buffer2.flush()
+            result_layer.update(0,0,w,h)
+            image.select_item(Gimp.ChannelOps.REPLACE, result_layer)
+        elif self.mode == "remove":
+            pass #TODO
+        
+        image.remove_layer(result_layer)
+
+        #dialog.destroy()
+        image.undo_group_end()
+        Gimp.displays_flush()
+
+        return procedure.new_return_values(Gimp.PDBStatusType.SUCCESS, None)
+        
  
-    
+    # linux only. windows uses "sam_inference.py"
+    def sam_infer(self, image_array, bounds, new_w, new_h, original_w, original_h):
+            
+        image = Image.fromarray(image_array)
+        im = np.array(image.resize((new_w, new_h)))
+
+        # load SAM
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        if SAM_VERSION == 1:
+            sam = sam_model_registry["vit_l"](checkpoint=sam_checkpoint)
+            sam.to(device=device)
+            predictor = SamPredictor(sam)
+        elif SAM_VERSION == 2:
+            sam2_model = build_sam2(sam_cfg, sam_checkpoint, device=device)
+            predictor = SAM2ImagePredictor(sam2_model)
+        predictor.set_image(im)
+
+        # sam prediction
+        masks, _, _ = predictor.predict(box=bounds, multimask_output=False)
+        mask_rgba = np.zeros((masks[0].shape[0], masks[0].shape[1], 4), dtype=np.uint8)
+
+        if self.mode == "select": #  make it transparent and white
+            # Set white (255, 255, 255) where the mask is True, and full opacity (alpha = 255)
+            mask_rgba[masks[0] == 1] = [255, 255, 255, 255]  # White with full opacity
+        elif self.mode == "remove": #  make it black and white
+            mask_rgba[masks[0] == 1] = [255, 255, 255, 255]  # White with full opacity
+            mask_rgba[masks[0] == 0] = [0, 0, 0, 255]        # Black with full opacity
+
+        # Convert the numpy array to an Image object
+        mask_image = Image.fromarray(mask_rgba)
+
+        return np.array(mask_image.resize((original_w, original_h)))
+
+
                 
 Gimp.main(SelectionRefinerSAM.__gtype__, sys.argv)

--- a/selection_refiner.py
+++ b/selection_refiner.py
@@ -23,8 +23,10 @@ baseLoc = os.path.dirname(os.path.realpath(__file__))
 
 if current_platform != "windows":
     for version in range(6,20):
-        sys.path.extend([baseLoc+f'gimpenv/lib/python3.{version}', baseLoc+f'gimpenv/lib/python3.{version}/site-packages', baseLoc+f'gimpenv/lib/python3.{version}/site-packages/setuptools'])
-    sys.path.extend([baseLoc+'gimpenv/Lib', baseLoc+'gimpenv/Lib/site-packages', baseLoc+'gimpenv/Lib/site-packages/setuptools'])
+        sys.path.extend([join(baseLoc,f'gimpenv/lib/python3.{version}'), 
+                         join(baseLoc,f'gimpenv/lib/python3.{version}/site-packages'), 
+                         join(baseLoc,f'gimpenv/lib/python3.{version}/site-packages/setuptools')])
+    sys.path.extend([join(baseLoc,'gimpenv/Lib'), join(baseLoc,'gimpenv/Lib/site-packages'), join(baseLoc,'gimpenv/Lib/site-packages/setuptools')])
     sys.path.extend([baseLoc])
 
 
@@ -44,17 +46,17 @@ if current_platform != "windows":
 
     # set checkpoint
     if SAM_VERSION == 1:
-        sam_checkpoint = os.path.join(baseLoc, "sam_vit_l_0b3195.pth")
+        sam_checkpoint = join(baseLoc, "sam_vit_l_0b3195.pth")
     elif SAM_VERSION == 2:
         if SAM_SIZE == "small":
             sam_cfg = "configs/sam2.1/sam2.1_hiera_s.yaml"
-            sam_checkpoint = os.path.join(baseLoc, "sam2.1_hiera_small.pt")
+            sam_checkpoint = join(baseLoc, "sam2.1_hiera_small.pt")
         elif SAM_SIZE == "large":
             sam_cfg = "configs/sam2.1/sam2.1_hiera_l.yaml"
-            sam_checkpoint = os.path.join(baseLoc, "sam2.1_hiera_large.pt")
+            sam_checkpoint = join(baseLoc, "sam2.1_hiera_large.pt")
         else: # base
             sam_cfg = "configs/sam2.1/sam2.1_hiera_b+.yaml"
-            sam_checkpoint = os.path.join(baseLoc, "sam2.1_hiera_base_plus.pt")
+            sam_checkpoint = join(baseLoc, "sam2.1_hiera_base_plus.pt")
 
 
 

--- a/selection_refiner.py
+++ b/selection_refiner.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 import os
+from os.path import join
 import sys
+import subprocess
 
-# This Plugin is only for GIMP Version >= 3.0.0 and linux
+# This Plugin is only for GIMP Version >= 3.0.0 and windows
 import gi
 gi.require_version('Gimp', '3.0')
 from gi.repository import Gimp
@@ -13,47 +15,14 @@ from gi.repository import GLib
 from gi.repository import Gegl
 from gi.repository import Gio
 
-baseLoc = os.path.dirname(os.path.realpath(__file__))+'/'
-for version in range(6,20):
-    sys.path.extend([baseLoc+f'gimpenv/lib/python3.{version}', baseLoc+f'gimpenv/lib/python3.{version}/site-packages', baseLoc+f'gimpenv/lib/python3.{version}/site-packages/setuptools'])
-sys.path.extend([baseLoc+'gimpenv/Lib', baseLoc+'gimpenv/Lib/site-packages', baseLoc+'gimpenv/Lib/site-packages/setuptools'])
-sys.path.extend([baseLoc])
 
-
-import numpy as np
-import torch
-from PIL import Image
-
-SAM_VERSION = 2
-SAM_SIZE = "base"
-
-if SAM_VERSION == 1:
-    from segment_anything import SamPredictor, sam_model_registry
-elif SAM_VERSION == 2:
-    from sam2.build_sam import build_sam2
-    from sam2.sam2_image_predictor import SAM2ImagePredictor
-
-
-# set checkpoint
-if SAM_VERSION == 1:
-    sam_checkpoint = os.path.join(baseLoc, "sam_vit_l_0b3195.pth")
-elif SAM_VERSION == 2:
-    if SAM_SIZE == "small":
-        sam_cfg = "configs/sam2.1/sam2.1_hiera_s.yaml"
-        sam_checkpoint = os.path.join(baseLoc, "sam2.1_hiera_small.pt")
-    elif SAM_SIZE == "large":
-        sam_cfg = "configs/sam2.1/sam2.1_hiera_l.yaml"
-        sam_checkpoint = os.path.join(baseLoc, "sam2.1_hiera_large.pt")
-    else: # base
-        sam_cfg = "configs/sam2.1/sam2.1_hiera_b+.yaml"
-        sam_checkpoint = os.path.join(baseLoc, "sam2.1_hiera_base_plus.pt")
-
+baseLoc = os.path.dirname(os.path.realpath(__file__))
 
 class SelectionRefinerSAM(Gimp.PlugIn):
 
     ## GimpPlugIn virtual methods ##
     def do_query_procedures(self):
-        return [ 'python-plugin-selection-refiner-sam' ]
+        return [ 'python-plugin-selection-refiner-sam-win' ]
 
 
     def do_create_procedure(self, name):
@@ -82,7 +51,9 @@ class SelectionRefinerSAM(Gimp.PlugIn):
         
         image.undo_group_start()
 
-        #GimpUi.init("python-plugin-selection-refiner-sam")
+
+
+        #GimpUi.init("python-plugin-selection-refiner-sam-win")
         #dialog = GimpUi.ProcedureDialog.new(procedure, config, "Run Plugin")
         #dialog.fill(["please wait"])
         #dialog.run()
@@ -93,31 +64,32 @@ class SelectionRefinerSAM(Gimp.PlugIn):
         new_w, new_h = int(w*scale), int(h*scale)
 
         selection = Gimp.Selection.bounds(image)
-        selection_bounds = np.array([selection.x1 * scale, selection.y1 * scale, 
-                                     selection.x2 * scale, selection.y2 * scale], dtype=np.int64)
+        x1, y1 = int(selection.x1 * scale), int(selection.y1 * scale)
+        x2, y2 = int(selection.x2 * scale), int(selection.y2 * scale)
+
+        rgb_file = Gio.file_new_for_path(join(baseLoc, "rgb.png"))
+        mask_file = Gio.file_new_for_path(join(baseLoc, "mask.png"))
+
+
+        Gimp.file_save(Gimp.RunMode.NONINTERACTIVE, image, rgb_file, None)
 
         
-        # get the image as numpy array (https://gitlab.gnome.org/GNOME/gimp/-/issues/8686)
-        rect = Gegl.Rectangle.new(0, 0, w, h)
-        buffer1 = layer.get_buffer()
-        buffer_bytes = buffer1.get(rect, 1.0, "RGBA u8", Gegl.AbyssPolicy(0))
-        image_arr = np.frombuffer(buffer_bytes, dtype=np.uint8).reshape((h,w,-1))
-
         #Inference
-        result_layer_arr = self.sam_inference(image_arr[:,:,:3], selection_bounds, new_w, new_h, w, h)
+        python_path = join(baseLoc, "gimpenv", "Scripts", "python.exe")
+        inference_script = join(baseLoc, "sam_inference.py")
+        args = [str(x1), str(y1), str(x2), str(y2), str(new_w), str(new_h), str(w), str(h), baseLoc]
+
+        command = [python_path, inference_script] + args
+
+        # Run the script using subprocess
+        subprocess.run(command)
         
-        result_layer = Gimp.Layer().new(image, "result", w, h, Gimp.ImageType.RGBA_IMAGE, 1, Gimp.LayerMode.NORMAL)
+        result_layer = Gimp.file_load_layer(Gimp.RunMode.NONINTERACTIVE, image, mask_file)
+
+        # insert layer because you cannot scale without adding the layer
         image.insert_layer(result_layer, None, 1)
-        buffer2 = result_layer.get_buffer()
-        if self.mode == "select":
-            rect = Gegl.Rectangle.new(0, 0, w, h)
-            buffer2.set(rect, "RGBA u8" , result_layer_arr.tobytes())
-            buffer2.flush()
-            result_layer.update(0,0,w,h)
-            image.select_item(Gimp.ChannelOps.REPLACE, result_layer)
-        elif self.mode == "remove":
-            pass #TODO
-        
+
+        image.select_item(Gimp.ChannelOps.REPLACE, result_layer)
         image.remove_layer(result_layer)
 
         #dialog.destroy()
@@ -127,36 +99,6 @@ class SelectionRefinerSAM(Gimp.PlugIn):
         return procedure.new_return_values(Gimp.PDBStatusType.SUCCESS, None)
         
  
-    def sam_inference(self, image_array, bounds, new_w, new_h, original_w, original_h):
-            
-        image = Image.fromarray(image_array)
-        im = np.array(image.resize((new_w, new_h)))
-
-        # load SAM
-        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-        if SAM_VERSION == 1:
-            sam = sam_model_registry["vit_l"](checkpoint=sam_checkpoint)
-            sam.to(device=device)
-            predictor = SamPredictor(sam)
-        elif SAM_VERSION == 2:
-            sam2_model = build_sam2(sam_cfg, sam_checkpoint, device=device)
-            predictor = SAM2ImagePredictor(sam2_model)
-        predictor.set_image(im)
-
-        # sam prediction
-        masks, _, _ = predictor.predict(box=bounds, multimask_output=False)
-        mask_rgba = np.zeros((masks[0].shape[0], masks[0].shape[1], 4), dtype=np.uint8)
-
-        if self.mode == "select": #  make it transparent and white
-            # Set white (255, 255, 255) where the mask is True, and full opacity (alpha = 255)
-            mask_rgba[masks[0] == 1] = [255, 255, 255, 255]  # White with full opacity
-        elif self.mode == "remove": #  make it black and white
-            mask_rgba[masks[0] == 1] = [255, 255, 255, 255]  # White with full opacity
-            mask_rgba[masks[0] == 0] = [0, 0, 0, 255]        # Black with full opacity
-
-        # Convert the numpy array to an Image object
-        mask_image = Image.fromarray(mask_rgba)
-
-        return np.array(mask_image.resize((original_w, original_h)))
+    
                 
 Gimp.main(SelectionRefinerSAM.__gtype__, sys.argv)

--- a/setup.bat
+++ b/setup.bat
@@ -1,0 +1,23 @@
+@echo off
+
+
+echo please wait ...
+
+
+python -m venv gimpenv
+call gimpenv\Scripts\activate.bat
+
+python -m pip install --upgrade pip
+
+echo "installing for CPU"
+python -m pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
+
+python -m pip install git+https://github.com/facebookresearch/segment-anything.git
+
+
+deactivate
+
+curl.exe -L -o sam_vit_b_01ec64.pth https://dl.fbaipublicfiles.com/segment_anything/sam_vit_b_01ec64.pth
+
+
+echo Virtual environment setup complete!

--- a/setup.bat
+++ b/setup.bat
@@ -7,17 +7,16 @@ echo please wait ...
 python -m venv gimpenv
 call gimpenv\Scripts\activate.bat
 
+echo Installing dependencies for CPU
 python -m pip install --upgrade pip
-
-echo "installing for CPU"
 python -m pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
-
 python -m pip install git+https://github.com/facebookresearch/segment-anything.git
 
 
 deactivate
 
-curl.exe -L -o sam_vit_b_01ec64.pth https://dl.fbaipublicfiles.com/segment_anything/sam_vit_b_01ec64.pth
+echo Downloding SAM2 base
+curl.exe -L -o sam2.1_hiera_base_plus.pt https://dl.fbaipublicfiles.com/segment_anything_2/092824/sam2.1_hiera_base_plus.pt
 
 
 echo Virtual environment setup complete!

--- a/setup.bat
+++ b/setup.bat
@@ -10,8 +10,7 @@ call gimpenv\Scripts\activate.bat
 echo Installing dependencies for CPU
 python -m pip install --upgrade pip
 python -m pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
-python -m pip install git+https://github.com/facebookresearch/segment-anything.git
-
+python -m pip install sam2
 
 deactivate
 


### PR DESCRIPTION
It now works for both linux and windows, but the execution differs:
For both platforms, a virtual python environment is created and the packages are installed in there. 

On linux, Gimp`s native python interpreter is used to execute sam by adding the additional packages to the path. 

On windows, this does not work, therefore the gimp script exports the image as png, and the python of the virtual evnironment is used to perform the inference and saves it to another png, which is then imported back into gimp,